### PR TITLE
feat: one time give support

### DIFF
--- a/src/nft.sol
+++ b/src/nft.sol
@@ -287,7 +287,7 @@ contract FundingNFT is ERC721, Ownable {
     }
 
     function topUp(uint256 tokenId, uint128 topUpAmt) public onlyTokenHolder(tokenId) {
-        require(nftTypes[tokenType(tokenId)].streaming && _exists(tokenId), "not-a-streaming-nft");
+        require(nftTypes[tokenType(tokenId)].streaming, "not-a-streaming-nft");
         dai.transferFrom(msg.sender, address(this), topUpAmt);
         Receiver[] memory receivers = _tokenReceivers(tokenId);
         pool.updateSubSender(tokenId, topUpAmt, 0, receivers, receivers);

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -180,7 +180,7 @@ contract FundingNFT is ERC721, Ownable {
         return uint128(tokenId >> 128);
     }
 
-    function mint(
+    function mintStreaming(
         address nftReceiver,
         uint128 typeId,
         uint128 topUpAmt,
@@ -192,7 +192,7 @@ contract FundingNFT is ERC721, Ownable {
         bytes32 s
     ) external returns (uint256) {
         dai.permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
-        return mint(nftReceiver, typeId, topUpAmt, amtPerSec);
+        return mintStreaming(nftReceiver, typeId, topUpAmt, amtPerSec);
     }
 
     // todo implement mint method with permit
@@ -208,6 +208,7 @@ contract FundingNFT is ERC721, Ownable {
         // one time give instead of streaming
         pool.giveFromSubSender(newTokenId, address(this), giveAmt);
         nfts[newTokenId].amt = giveAmt;
+        emit NewNFT(newTokenId, nftReceiver, typeId, giveAmt);
     }
 
     function _mintInternal(address nftReceiver,
@@ -222,7 +223,7 @@ contract FundingNFT is ERC721, Ownable {
         dai.transferFrom(nftReceiver, address(this), topUpAmt);
     }
 
-    function mint(
+    function mintStreaming(
         address nftReceiver,
         uint128 typeId,
         uint128 topUpAmt,

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -215,8 +215,7 @@ contract FundingNFT is ERC721, Ownable {
         uint128 giveAmt
     ) public returns (uint256 newTokenId) {
         require(giveAmt > nftTypes[typeId].minAmt, "giveAmt-too-low");
-        require(nftTypes[typeId].streaming, "nft-type-not-streaming");
-
+        require(nftTypes[typeId].streaming == false, "type-is-streaming");
         newTokenId = _mintInternal(nftReceiver, typeId, giveAmt);
         // one time give instead of streaming
         pool.giveFromSubSender(newTokenId, address(this), giveAmt);
@@ -244,6 +243,7 @@ contract FundingNFT is ERC721, Ownable {
         uint128 amtPerSec
     ) public returns (uint256 newTokenId) {
         require(amtPerSec >= nftTypes[typeId].minAmt, "amt-per-sec-too-low");
+        require(nftTypes[typeId].streaming, "nft-type-not-streaming");
         uint128 cycleSecs = uint128(pool.cycleSecs());
         require(topUpAmt >= amtPerSec * cycleSecs, "toUp-too-low");
 

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -12,7 +12,9 @@ import {DaiPool, IDai} from "../lib/radicle-streaming/src/DaiPool.sol";
 struct InputNFTType {
     uint128 nftTypeId;
     uint64 limit;
-    uint128 minAmtPerSec;
+    // minimum amtPerSecond or minGiveAmt
+    uint128 minAmt;
+    bool streaming;
     string ipfsHash;
 }
 
@@ -35,27 +37,36 @@ contract FundingNFT is ERC721, Ownable {
     struct NFTType {
         uint64 limit;
         uint64 minted;
-        uint128 minAmtPerSec;
+        uint128 minAmt;
+        bool streaming;
         string ipfsHash;
     }
 
     struct NFT {
         uint64 minted;
-        uint128 amtPerSecond;
+        // amtPerSec if the NFT is streaming otherwise the amt given at mint
+        uint128 amt;
     }
 
     mapping(uint128 => NFTType) public nftTypes;
     mapping(uint256 => NFT) public nfts;
 
     // events
-    event NewNFTType(uint128 indexed nftType, uint64 limit, uint128 minAmtPerSec);
-    event NewNFT(
+    event NewNFTType(uint128 indexed nftType, uint64 limit, uint128 minAmt, bool streaming);
+    event NewStreamingNFT(
         uint256 indexed tokenId,
         address indexed receiver,
         uint128 indexed typeId,
         uint128 topUp,
         uint128 amtPerSec
     );
+    event NewNFT(
+        uint256 indexed tokenId,
+        address indexed receiver,
+        uint128 indexed typeId,
+        uint128 giveAmt
+    );
+
     event NewContractURI(string contractURI);
     event NewBuilder(IBuilder builder);
     event DripsUpdated(uint32 dripFraction, Receiver[] drips);
@@ -119,34 +130,46 @@ contract FundingNFT is ERC721, Ownable {
             _addType(
                 inputNFTTypes[i].nftTypeId,
                 inputNFTTypes[i].limit,
-                inputNFTTypes[i].minAmtPerSec,
-                inputNFTTypes[i].ipfsHash
+                inputNFTTypes[i].minAmt,
+                inputNFTTypes[i].ipfsHash,
+                inputNFTTypes[i].streaming
             );
         }
     }
 
-    function addType(
+    function addStreamingType(
         uint128 newTypeId,
         uint64 limit,
         uint128 minAmtPerSec,
         string memory ipfsHash
     ) public onlyOwner {
-        _addType(newTypeId, limit, minAmtPerSec, ipfsHash);
+        _addType(newTypeId, limit, minAmtPerSec, ipfsHash, true);
+    }
+
+    function addType(
+        uint128 newTypeId,
+        uint64 limit,
+        uint128 minGiveAmt,
+        string memory ipfsHash
+    ) public onlyOwner {
+        _addType(newTypeId, limit, minGiveAmt, ipfsHash, false);
     }
 
     function _addType(
         uint128 newTypeId,
         uint64 limit,
-        uint128 minAmtPerSec,
-        string memory ipfsHash
+        uint128 minAmt,
+        string memory ipfsHash,
+        bool streaming
     ) internal {
         require(nftTypes[newTypeId].limit == 0, "nft-type-already-exists");
         require(limit > 0, "zero-limit-not-allowed");
 
-        nftTypes[newTypeId].minAmtPerSec = minAmtPerSec;
+        nftTypes[newTypeId].minAmt = minAmt;
         nftTypes[newTypeId].limit = limit;
         nftTypes[newTypeId].ipfsHash = ipfsHash;
-        emit NewNFTType(newTypeId, limit, minAmtPerSec);
+        nftTypes[newTypeId].streaming = streaming;
+        emit NewNFTType(newTypeId, limit, minAmt, streaming);
     }
 
     function createTokenId(uint128 id, uint128 nftType) public pure returns (uint256 tokenId) {
@@ -172,32 +195,48 @@ contract FundingNFT is ERC721, Ownable {
         return mint(nftReceiver, typeId, topUpAmt, amtPerSec);
     }
 
+    // todo implement mint method with permit
+
+    function mint(
+        address nftReceiver,
+        uint128 typeId,
+        uint128 giveAmt
+    ) public returns (uint256 newTokenId) {
+        require(giveAmt > nftTypes[typeId].minAmt, "giveAmt-too-low");
+
+        newTokenId = _mintInternal(nftReceiver, typeId, giveAmt);
+        // one time give instead of streaming
+        pool.giveFromSubSender(newTokenId, address(this), giveAmt);
+        nfts[newTokenId].amt = giveAmt;
+    }
+
+    function _mintInternal(address nftReceiver,
+        uint128 typeId,
+        uint128 topUpAmt) internal returns(uint newTokenId) {
+
+        require(nftTypes[typeId].minted++ < nftTypes[typeId].limit, "nft-type-reached-limit");
+        newTokenId = createTokenId(nftTypes[typeId].minted, typeId);
+        _mint(nftReceiver, newTokenId);
+        nfts[newTokenId].minted = uint64(block.timestamp);
+        // transfer currency to NFT registry
+        dai.transferFrom(nftReceiver, address(this), topUpAmt);
+    }
+
     function mint(
         address nftReceiver,
         uint128 typeId,
         uint128 topUpAmt,
         uint128 amtPerSec
-    ) public returns (uint256) {
-        require(amtPerSec >= nftTypes[typeId].minAmtPerSec, "amt-per-sec-too-low");
+    ) public returns (uint256 newTokenId) {
+        require(amtPerSec >= nftTypes[typeId].minAmt, "amt-per-sec-too-low");
         uint128 cycleSecs = uint128(pool.cycleSecs());
         require(topUpAmt >= amtPerSec * cycleSecs, "toUp-too-low");
-        require(nftTypes[typeId].minted++ < nftTypes[typeId].limit, "nft-type-reached-limit");
 
-        uint256 newTokenId = createTokenId(nftTypes[typeId].minted, typeId);
-
-        _mint(nftReceiver, newTokenId);
-        nfts[newTokenId].minted = uint64(block.timestamp);
-        nfts[newTokenId].amtPerSecond = amtPerSec;
-
-        // transfer currency to NFT registry
-        dai.transferFrom(nftReceiver, address(this), topUpAmt);
-
-        // start streaming
+        newTokenId = _mintInternal(nftReceiver, typeId, topUpAmt);
+            // start streaming
         pool.updateSubSender(newTokenId, topUpAmt, 0, _receivers(0), _receivers(amtPerSec));
-
-        emit NewNFT(newTokenId, nftReceiver, typeId, topUpAmt, amtPerSec);
-
-        return newTokenId;
+        nfts[newTokenId].amt = amtPerSec;
+        emit NewStreamingNFT(newTokenId, nftReceiver, typeId, topUpAmt, amtPerSec);
     }
 
     function collect(Receiver[] calldata currDrips)
@@ -270,7 +309,10 @@ contract FundingNFT is ERC721, Ownable {
     }
 
     function withdrawable(uint256 tokenId) public view returns (uint128) {
-        uint128 amtPerSec = nfts[tokenId].amtPerSecond;
+        if (nftTypes[tokenType(tokenId)].streaming == false) {
+            return 0;
+        }
+        uint128 amtPerSec = nfts[tokenId].amt;
         uint128 withdrawable_ = pool.withdrawableSubSender(
             address(this),
             tokenId,
@@ -292,11 +334,11 @@ contract FundingNFT is ERC721, Ownable {
         if (!_exists(tokenId)) {
             return 0;
         }
-
-        if (nftTypes[tokenType(tokenId)].minAmtPerSec == 0) {
+        uint128 amtPerSec = nfts[tokenId].amt;
+        if (nftTypes[tokenType(tokenId)].streaming == false || amtPerSec == 0) {
             return type(uint128).max;
         }
-        uint128 amtPerSec = nfts[tokenId].amtPerSecond;
+
         uint128 amtWithdrawable = pool.withdrawableSubSender(
             address(this),
             tokenId,
@@ -307,6 +349,10 @@ contract FundingNFT is ERC721, Ownable {
 
     function active(uint256 tokenId) public view returns (bool) {
         return activeUntil(tokenId) >= block.timestamp;
+    }
+
+    function streaming(uint256 tokenId) public view returns (bool) {
+        return nftTypes[tokenType(tokenId)].streaming;
     }
 
     function name() public view override returns (string memory) {
@@ -329,7 +375,7 @@ contract FundingNFT is ERC721, Ownable {
                 builder.buildMetaData(
                     name(),
                     tokenId,
-                    nfts[tokenId].amtPerSecond * pool.cycleSecs(),
+                    nfts[tokenId].amt * pool.cycleSecs(),
                     active(tokenId)
                 );
         }
@@ -337,7 +383,7 @@ contract FundingNFT is ERC721, Ownable {
             builder.buildMetaData(
                 name(),
                 tokenId,
-                nfts[tokenId].amtPerSecond * pool.cycleSecs(),
+                nfts[tokenId].amt * pool.cycleSecs(),
                 active(tokenId),
                 ipfsHash
             );
@@ -350,13 +396,13 @@ contract FundingNFT is ERC721, Ownable {
 
     function influence(uint256 tokenId) public view returns (uint256 influenceScore) {
         if (active(tokenId)) {
-            return nfts[tokenId].amtPerSecond;
+            return nfts[tokenId].amt;
         }
         return 0;
     }
 
     function _tokenReceivers(uint256 tokenId) internal view returns (Receiver[] memory receivers) {
-        return _receivers(nfts[tokenId].amtPerSecond);
+        return _receivers(nfts[tokenId].amt);
     }
 
     function _receivers(uint128 amtPerSec) internal view returns (Receiver[] memory receivers) {

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -215,6 +215,7 @@ contract FundingNFT is ERC721, Ownable {
         uint128 giveAmt
     ) public returns (uint256 newTokenId) {
         require(giveAmt > nftTypes[typeId].minAmt, "giveAmt-too-low");
+        require(nftTypes[typeId].streaming, "nft-type-not-streaming");
 
         newTokenId = _mintInternal(nftReceiver, typeId, giveAmt);
         // one time give instead of streaming

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -272,6 +272,7 @@ contract FundingNFT is ERC721, Ownable {
     }
 
     function topUp(uint256 tokenId, uint128 topUpAmt) public onlyTokenHolder(tokenId) {
+        require(nftTypes[tokenType(tokenId)].streaming && _exists(tokenId), "not-a-streaming-nft");
         dai.transferFrom(msg.sender, address(this), topUpAmt);
         Receiver[] memory receivers = _tokenReceivers(tokenId);
         pool.updateSubSender(tokenId, topUpAmt, 0, receivers, receivers);

--- a/src/nft.sol
+++ b/src/nft.sol
@@ -195,7 +195,19 @@ contract FundingNFT is ERC721, Ownable {
         return mintStreaming(nftReceiver, typeId, topUpAmt, amtPerSec);
     }
 
-    // todo implement mint method with permit
+    function mint(
+        address nftReceiver,
+        uint128 typeId,
+        uint128 amtGive,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256) {
+        dai.permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
+        return mint(nftReceiver, typeId, amtGive);
+    }
 
     function mint(
         address nftReceiver,
@@ -211,10 +223,11 @@ contract FundingNFT is ERC721, Ownable {
         emit NewNFT(newTokenId, nftReceiver, typeId, giveAmt);
     }
 
-    function _mintInternal(address nftReceiver,
+    function _mintInternal(
+        address nftReceiver,
         uint128 typeId,
-        uint128 topUpAmt) internal returns(uint newTokenId) {
-
+        uint128 topUpAmt
+    ) internal returns (uint256 newTokenId) {
         require(nftTypes[typeId].minted++ < nftTypes[typeId].limit, "nft-type-reached-limit");
         newTokenId = createTokenId(nftTypes[typeId].minted, typeId);
         _mint(nftReceiver, newTokenId);
@@ -234,7 +247,7 @@ contract FundingNFT is ERC721, Ownable {
         require(topUpAmt >= amtPerSec * cycleSecs, "toUp-too-low");
 
         newTokenId = _mintInternal(nftReceiver, typeId, topUpAmt);
-            // start streaming
+        // start streaming
         pool.updateSubSender(newTokenId, topUpAmt, 0, _receivers(0), _receivers(amtPerSec));
         nfts[newTokenId].amt = amtPerSec;
         emit NewStreamingNFT(newTokenId, nftReceiver, typeId, topUpAmt, amtPerSec);

--- a/src/test/nft.t.sol
+++ b/src/test/nft.t.sol
@@ -605,7 +605,6 @@ contract NFTRegistryTest is BaseTest {
         uint64 limit = 1;
         uint128 giveAmt = 110 ether;
         setup1TimeSupport(minGiveAmt, limit, nftTypeId, giveAmt);
-        uint256 preBalance = dai.balanceOf(nftRegistry_);
         (uint128 collected, ) = nftRegistry.collect(noDrips());
         assertEq(collected, giveAmt);
     }

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -61,10 +61,10 @@ contract RegistryTest is BaseTest {
         assertEq(nftRegistry.contractURI(), ipfsHash);
         assertEq(address(nftRegistry.pool()), address(pool));
         assertEq(address(radicleRegistry.projectAddr(0)), address(nftRegistry));
-        (uint64 limit, uint64 minted, uint128 minAmtPerSec, ,) = nftRegistry.nftTypes(0);
+        (uint64 limit, uint64 minted, uint128 minAmtPerSec, , ) = nftRegistry.nftTypes(0);
         assertEq(limit, limitTypeZero);
         assertEq(minAmtPerSec, 10);
-        (limit, minted, minAmtPerSec, ,) = nftRegistry.nftTypes(1);
+        (limit, minted, minAmtPerSec, , ) = nftRegistry.nftTypes(1);
         assertEq(limit, limitTypeOne);
         assertEq(minAmtPerSec, 20);
         return address(nftRegistry);

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -35,14 +35,16 @@ contract RegistryTest is BaseTest {
         nftTypes[0] = InputNFTType({
             nftTypeId: 0,
             limit: limitTypeZero,
-            minAmtPerSec: 10,
-            ipfsHash: ""
+            minAmt: 10,
+            ipfsHash: "",
+            streaming: true
         });
         nftTypes[1] = InputNFTType({
             nftTypeId: 1,
             limit: limitTypeOne,
-            minAmtPerSec: 20,
-            ipfsHash: ""
+            minAmt: 20,
+            ipfsHash: "",
+            streaming: true
         });
 
         FundingNFT nftRegistry = radicleRegistry.newProject(
@@ -59,10 +61,10 @@ contract RegistryTest is BaseTest {
         assertEq(nftRegistry.contractURI(), ipfsHash);
         assertEq(address(nftRegistry.pool()), address(pool));
         assertEq(address(radicleRegistry.projectAddr(0)), address(nftRegistry));
-        (uint64 limit, uint64 minted, uint128 minAmtPerSec, ) = nftRegistry.nftTypes(0);
+        (uint64 limit, uint64 minted, uint128 minAmtPerSec, ,) = nftRegistry.nftTypes(0);
         assertEq(limit, limitTypeZero);
         assertEq(minAmtPerSec, 10);
-        (limit, minted, minAmtPerSec, ) = nftRegistry.nftTypes(1);
+        (limit, minted, minAmtPerSec, ,) = nftRegistry.nftTypes(1);
         assertEq(limit, limitTypeOne);
         assertEq(minAmtPerSec, 20);
         return address(nftRegistry);


### PR DESCRIPTION
The PR is still in draft mode but I think it is good to discuss the idea.

I think we should have a clear separation between on-time give and streaming supporters.

**One Time Give**
- the NFT type has a minGiveAmt
- no interaction with the pool contract
- not possible to lock funds
- will not get inactive
- influence => giveAmt 

We need an additional flag to indicate if it is a streaming supporter.

Just storing `minAmtPer = 0` is not possible because we still want to have a `minGiveAmt`. 

First, I wanted to keep just one `mint` method but `amt` would have different purposes depending on the streaming flag. The user should not confuse this two.

I will work on the overall naming in a separate PR


