### PR TITLE
Drop WITHDRAW_ALL

### DIFF
--- a/src/nft.sol
+++ b/src/nft.sol
@@ -22,9 +22,6 @@ struct DripInput {
 }
 
 contract FundingNFT is ERC721, Ownable {
-    /// @notice The amount passed as the withdraw amount to withdraw all the withdrawable funds
-    uint128 public constant WITHDRAW_ALL = type(uint128).max;
-
     address public immutable deployer;
     DaiPool public immutable pool;
     IDai public immutable dai;
@@ -247,10 +244,8 @@ contract FundingNFT is ERC721, Ownable {
         returns (uint128 withdrawn)
     {
         uint128 withdrawableAmt = withdrawable(tokenId);
-        if (withdrawAmt == WITHDRAW_ALL) {
+        if (withdrawAmt > withdrawableAmt) {
             withdrawAmt = withdrawableAmt;
-        } else {
-            require(withdrawAmt <= withdrawableAmt, "withdraw-amount-too-high");
         }
         Receiver[] memory receivers = _tokenReceivers(tokenId);
         withdrawn = pool.updateSubSender(tokenId, 0, withdrawAmt, receivers, receivers);

--- a/src/test/nft.t.sol
+++ b/src/test/nft.t.sol
@@ -300,7 +300,7 @@ contract NFTRegistryTest is BaseTest {
         assertEq(withdrawableAfter, withdrawableBefore - withdrawn, "invalid-withdrawable");
     }
 
-    function testWithdrawAll() public {
+    function testWithdrawingMoreThanWithdrawable() public {
         uint128 initial = 30 ether;
         dai.approve(address(nftRegistry), initial);
         uint256 tokenId = nftRegistry.mint(
@@ -312,30 +312,12 @@ contract NFTRegistryTest is BaseTest {
         uint256 balanceBefore = dai.balanceOf(address(this));
         uint128 withdrawable = nftRegistry.withdrawable(tokenId);
 
-        uint256 withdrawnActual = nftRegistry.withdraw(tokenId, nftRegistry.WITHDRAW_ALL());
+        uint256 withdrawnActual = nftRegistry.withdraw(tokenId, withdrawable + 1);
 
         assertEq(withdrawnActual, withdrawable, "invalid-withdrawn");
         uint256 balanceAfter = dai.balanceOf(address(this));
         assertEq(balanceAfter, balanceBefore + withdrawable, "invalid-balance");
         assertEq(nftRegistry.withdrawable(tokenId), 0, "invalid-withdrawable");
-    }
-
-    function testWithdrawTooMuchFails() public {
-        uint128 initial = 30 ether;
-        dai.approve(address(nftRegistry), initial);
-        uint256 tokenId = nftRegistry.mint(
-            address(this),
-            DEFAULT_NFT_TYPE,
-            initial,
-            defaultMinAmtPerSec
-        );
-        uint128 withdrawable = nftRegistry.withdrawable(tokenId);
-
-        try nftRegistry.withdraw(tokenId, withdrawable + 1) {
-            assertTrue(false, "withdraw-hasnt-reverted");
-        } catch Error(string memory reason) {
-            assertEq(reason, "withdraw-amount-too-high", "invalid-withdraw-revert-reason");
-        }
     }
 
     function testWithdrawForNotOwnedTokenFails() public {


### PR DESCRIPTION
Makes the API tolerate requests for withdrawal of more than is available, they get lowered to withdrawal of everything. This in turn allows dropping the `WITHDRAW_ALL` constant and a special-case behavior. I can't come up with any use case in which throwing would be useful.