### PR TITLE
feat: added governance contract

### DIFF
--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -66,6 +66,6 @@ contract Executor {
 
     function exec(address spell) public returns (bytes memory out) {
         require(msg.sender == owner, "notOwner");
-        return Address.functionDelegateCall(spell, SIG);
+        return Address.functionDelegateCall(spell, SIG, "spell-execution-failed");
     }
 }

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -3,6 +3,7 @@
 
 pragma solidity ^0.8.7;
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+import {Address} from "openzeppelin-contracts/utils/Address.sol";
 
 // inspired by MakerDAO DSPaused
 contract Governance is Ownable {
@@ -98,21 +99,14 @@ contract Governance is Ownable {
 // malicious storage modification during execution
 // inspired by MakerDAO DSPauseProxy
 contract Executor {
-    address public owner;
-    modifier onlyOwner() {
-        require(msg.sender == owner, "notOwner");
-        _;
-    }
+    address public immutable owner;
 
     constructor() {
         owner = msg.sender;
     }
 
-    function exec(address usr, bytes memory fax) public onlyOwner returns (bytes memory out) {
-        bool ok;
-        address currOwner = owner;
-        (ok, out) = usr.delegatecall(fax);
-        require(owner == currOwner, "owner-not-changable");
-        require(ok, "delegatecall-error");
+    function exec(address usr, bytes memory fax) public returns (bytes memory out) {
+        require(msg.sender == owner, "notOwner");
+        return Address.functionDelegateCall(usr, fax);
     }
 }

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// solhint-disable avoid-low-level-calls
+pragma solidity ^0.8.7;
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+
+// inspired by MakerDAO DSPaused
+contract Governance is Ownable {
+    mapping(bytes32 => bool) public scheduler;
+    mapping(address => bool) public approvedSpells;
+
+    modifier onlyApprovedSpells() {
+        require(approvedSpells[msg.sender] == true || msg.sender == owner(), "spell-not-approved");
+        _;
+    }
+
+    Executor public executor;
+
+    event Scheduled(address spell, bytes sig, uint256 earliestExeTime, bytes32 scheduleHash);
+    event Unscheduled(address spell, bytes sig, uint256 earliestExeTime, bytes32 scheduleHash);
+    event Executed(address spell, bytes sig, uint256 earliestExeTime, bytes32 scheduleHash);
+
+    event ApproveSpell(address spell);
+    event DenySpell(address spell);
+
+    constructor(address owner_) {
+        executor = new Executor();
+        _transferOwnership(owner_);
+    }
+
+    function hash(
+        address spell,
+        bytes memory sig,
+        uint256 earliestExeTime
+    ) public pure returns (bytes32 hash_) {
+        return keccak256(abi.encode(spell, sig, earliestExeTime));
+    }
+
+    function schedule(
+        address spell,
+        bytes memory sig,
+        uint256 earliestExeTime
+    ) public onlyApprovedSpells {
+        require(earliestExeTime >= block.timestamp, "exe-time-not-in-the-future");
+        bytes32 hash_ = hash(spell, sig, earliestExeTime);
+        scheduler[hash_] = true;
+        emit Scheduled(spell, sig, earliestExeTime, hash_);
+    }
+
+    function unSchedule(
+        address spell,
+        bytes memory sig,
+        uint256 earliestExeTime
+    ) public onlyApprovedSpells {
+        bytes32 hash_ = hash(spell, sig, earliestExeTime);
+        scheduler[hash(spell, sig, earliestExeTime)] = false;
+        emit Scheduled(spell, sig, earliestExeTime, hash_);
+    }
+
+    // can be called by anyone after delay has passed
+    function execute(
+        address spell,
+        bytes memory sig,
+        uint256 earliestExeTime
+    ) public {
+        bytes32 hash_ = hash(spell, sig, earliestExeTime);
+        require(scheduler[hash_], "unknown_spell");
+        require(block.timestamp >= earliestExeTime, "execution-too-early");
+
+        executor.exec(spell, sig);
+        scheduler[hash_] = false;
+        emit Executed(spell, sig, earliestExeTime, hash_);
+    }
+
+    function approveSpell(address spell) public onlyOwner {
+        approvedSpells[spell] = true;
+        emit ApproveSpell(spell);
+    }
+
+    function denySpell(address spell) public onlyOwner {
+        approvedSpells[spell] = false;
+        emit DenySpell(spell);
+    }
+}
+
+// plans are executed in an isolated storage context to protect the Governance from
+// malicious storage modification during execution
+// inspired by MakerDAO DSPauseProxy
+contract Executor is Ownable {
+    function exec(address usr, bytes memory fax) public onlyOwner returns (bytes memory out) {
+        bool ok;
+        address currOwner = owner();
+        (ok, out) = usr.delegatecall(fax);
+        require(owner() == currOwner, "owner-not-changable");
+        require(ok, "delegatecall-error");
+    }
+}

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // solhint-disable avoid-low-level-calls
-// solhint-disable no-inline-assembly
+
 pragma solidity ^0.8.7;
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
 

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -63,7 +63,7 @@ contract Governance is Ownable {
         uint256 earliestExeTime
     ) public {
         bytes32 hash_ = hash(spell, sig, earliestExeTime);
-        require(scheduler[hash_], "unknown_spell");
+        require(scheduler[hash_], "unknown-spell");
         require(block.timestamp >= earliestExeTime, "execution-too-early");
 
         executor.exec(spell, sig);

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -50,7 +50,7 @@ contract Governance is Ownable {
         bytes32 spellActionHash,
         bytes memory sig,
         uint256 startTime
-    ) public onlyApprovedSpells returns(bytes32 hash_) {
+    ) public onlyApprovedSpells returns (bytes32 hash_) {
         require(startTime >= block.timestamp + executor.minDelay(), "exe-time-not-in-the-future");
         require(spellActionHash == _getContractHash(spellActionAddr), "bytecode-not-matching");
         hash_ = hash(spellActionAddr, spellActionHash, sig, startTime);
@@ -104,7 +104,7 @@ contract Executor {
     address public immutable owner;
 
     // governance parameter which can be changed by spells
-    uint public minDelay = 0;
+    uint256 public minDelay = 0;
 
     constructor() {
         owner = msg.sender;

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // solhint-disable avoid-low-level-calls
+// solhint-disable no-inline-assembly
 pragma solidity ^0.8.7;
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
 
@@ -27,11 +28,10 @@ contract Governance is Ownable {
         _transferOwnership(owner_);
     }
 
-    function _getContractHash(address spell)
-        internal view
-        returns (bytes32 h)
-    {
-        assembly { h := extcodehash(spell) }
+    function _getContractHash(address spell) internal view returns (bytes32 h) {
+        assembly {
+            h := extcodehash(spell)
+        }
     }
 
     function hash(

--- a/src/governance/governance.sol
+++ b/src/governance/governance.sol
@@ -96,12 +96,22 @@ contract Governance is Ownable {
 // plans are executed in an isolated storage context to protect the Governance from
 // malicious storage modification during execution
 // inspired by MakerDAO DSPauseProxy
-contract Executor is Ownable {
+contract Executor {
+    address public owner;
+    modifier onlyOwner() {
+        require(msg.sender == owner, "notOwner");
+        _;
+    }
+
+    constructor() {
+        owner = msg.sender;
+    }
+
     function exec(address usr, bytes memory fax) public onlyOwner returns (bytes memory out) {
         bool ok;
-        address currOwner = owner();
+        address currOwner = owner;
         (ok, out) = usr.delegatecall(fax);
-        require(owner() == currOwner, "owner-not-changable");
+        require(owner == currOwner, "owner-not-changable");
         require(ok, "delegatecall-error");
     }
 }

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+// solhint-disable no-inline-assembly
 pragma solidity ^0.8.7;
 
 import "ds-test/test.sol";
@@ -34,7 +35,7 @@ contract ChangeValueSpell {
     uint256 public earliestExeTime;
     bool public done;
     uint256 public delay;
-    bytes32 actionHash;
+    bytes32 public actionHash;
 
     constructor(
         Governance governance_,
@@ -45,7 +46,10 @@ contract ChangeValueSpell {
         address action_ = address(new ChangeValueSpellAction());
         governance = governance_;
         delay = delay_;
-        bytes32 actionHash_; assembly { actionHash_ := extcodehash(action_) }
+        bytes32 actionHash_;
+        assembly {
+            actionHash_ := extcodehash(action_)
+        }
         action = action_;
         actionHash = actionHash_;
     }
@@ -94,7 +98,10 @@ contract GovernanceTest is DSTest {
     function testScheduleExecuteDirectly() public {
         bytes memory sig = abi.encodeWithSignature("execute(address)", dripsContract);
         address action = address(new ChangeValueSpellAction());
-        bytes32 actionHash; assembly { actionHash := extcodehash(action) }
+        bytes32 actionHash;
+        assembly {
+            actionHash := extcodehash(action)
+        }
         governance.schedule(action, actionHash, sig, block.timestamp);
         assertPreCondition();
         governance.execute(action, actionHash, sig, block.timestamp);
@@ -113,7 +120,10 @@ contract GovernanceTest is DSTest {
     function testExecuteWithoutSchedule() public {
         bytes memory sig = abi.encodeWithSignature("execute(address)", dripsContract);
         address action = address(new ChangeValueSpellAction());
-        bytes32 actionHash; assembly { actionHash := extcodehash(action) }
+        bytes32 actionHash;
+        assembly {
+            actionHash := extcodehash(action)
+        }
         try governance.execute(action, actionHash, sig, block.timestamp) {
             assertTrue(false, "execute-schould-revert");
         } catch Error(string memory reason) {
@@ -124,7 +134,10 @@ contract GovernanceTest is DSTest {
     function testTimeDelay() public {
         bytes memory sig = abi.encodeWithSignature("execute(address)", dripsContract);
         address action = address(new ChangeValueSpellAction());
-        bytes32 actionHash; assembly { actionHash := extcodehash(action) }
+        bytes32 actionHash;
+        assembly {
+            actionHash := extcodehash(action)
+        }
         governance.schedule(action, actionHash, sig, block.timestamp + 1 days);
         assertPreCondition();
         try governance.execute(action, actionHash, sig, block.timestamp) {

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -31,10 +31,11 @@ contract ChangeValueSpellAction {
 contract GovernanceDelaySpellAction {
     // storage of executor
     // immutable variables like owner are not part of the storage
-    uint minDelay; // first slot
+    uint256 public minDelay; // first slot
 
     // constant and in spell action
-    uint constant public MIN_DELAY = 1 days;
+    uint256 public constant MIN_DELAY = 1 days;
+
     function execute() public {
         minDelay = MIN_DELAY;
     }
@@ -171,7 +172,7 @@ contract GovernanceTest is DSTest {
         }
         bytes32 scheduleHash = governance.schedule(action, actionHash, sig, block.timestamp);
         assertTrue(governance.scheduler(scheduleHash), "not-scheduled");
-        
+
         governance.unSchedule(action, actionHash, sig, block.timestamp);
         assertTrue(governance.scheduler(scheduleHash) == false, "not-un-scheduled");
     }
@@ -192,6 +193,5 @@ contract GovernanceTest is DSTest {
 
         // post condition
         assertEq(e.minDelay(), 1 days, "delay-pre-condition");
-
     }
 }

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -149,4 +149,19 @@ contract GovernanceTest is DSTest {
         governance.execute(action, actionHash, sig, block.timestamp);
         assertPostCondition();
     }
+
+    function testUnSchedule() public {
+        bytes memory sig = abi.encodeWithSignature("execute(address)", dripsContract);
+        address action = address(new ChangeValueSpellAction());
+        bytes32 actionHash;
+        assembly {
+            actionHash := extcodehash(action)
+        }
+        bytes32 scheduleHash = governance.schedule(action, actionHash, sig, block.timestamp);
+        assertTrue(governance.scheduler(scheduleHash), "not-scheduled");
+        
+        governance.unSchedule(action, actionHash, sig, block.timestamp);
+        assertTrue(governance.scheduler(scheduleHash) == false, "not-un-scheduled");
+
+    }
 }

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import "ds-test/test.sol";
+import {Governance} from "./governance.sol";
+import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
+
+// contract should be maintained by governance
+contract DripsContract is Ownable {
+    constructor(address owner_) {
+        _transferOwnership(owner_);
+    }
+
+    uint256 public value = 0;
+
+    function setValue(uint256 newValue) public onlyOwner {
+        value = newValue;
+    }
+}
+
+// contract which performs a set of instructions
+// no state
+contract ChangeValueSpellAction {
+    function execute(DripsContract dripsContract) public {
+        dripsContract.setValue(1);
+    }
+}
+
+contract ChangeValueSpell {
+    bytes public sig;
+    address public action;
+    Governance public governance;
+    uint256 public earliestExeTime;
+    bool public done;
+    uint256 public delay;
+
+    constructor(
+        Governance governance_,
+        address dripsContract,
+        uint256 delay_
+    ) {
+        sig = abi.encodeWithSignature("execute(address)", dripsContract);
+        action = address(new ChangeValueSpellAction());
+        governance = governance_;
+        delay = delay_;
+    }
+
+    function schedule() public {
+        require(earliestExeTime == 0, "already-scheduled");
+        earliestExeTime = block.timestamp + delay;
+        governance.schedule(action, sig, earliestExeTime);
+    }
+
+    function cast() public {
+        require(!done, "spell-already-cast");
+        done = true;
+        governance.execute(action, sig, earliestExeTime);
+    }
+}
+
+contract GovernanceTest is DSTest {
+    Governance public governance;
+    DripsContract public dripsContract;
+
+    function setUp() public {
+        governance = new Governance(address(this));
+        dripsContract = new DripsContract(address(governance.executor()));
+    }
+
+    function assertPreCondition() public {
+        assertEq(dripsContract.value(), 0, "pre-condition-err");
+    }
+
+    function assertPostCondition() public {
+        assertEq(dripsContract.value(), 1, "post-condition-err");
+    }
+
+    function testSpell() public {
+        ChangeValueSpell spell = new ChangeValueSpell(governance, address(dripsContract), 0);
+        governance.approveSpell(address(spell));
+        spell.schedule();
+        assertPreCondition();
+        spell.cast();
+        assertPostCondition();
+    }
+
+    function testScheduleExecuteDirectly() public {
+        bytes memory sig = abi.encodeWithSignature("execute(address)", dripsContract);
+        address action = address(new ChangeValueSpellAction());
+        governance.schedule(action, sig, block.timestamp);
+        assertPreCondition();
+        governance.execute(action, sig, block.timestamp);
+        assertPostCondition();
+    }
+}

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -133,4 +133,20 @@ contract GovernanceTest is DSTest {
         // post condition
         assertEq(e.minDelay(), 1 days, "delay-pre-condition");
     }
+
+    function testScheduleNotOwner() public {
+        governance.transferOwnership(address(0xA));
+        address spell = address(new ChangeValueSpell(dripsContract));
+        try governance.schedule(address(spell), block.timestamp) {
+            assertTrue(false, "schedule-should-revert");
+        } catch Error(string memory reason) {
+            assertEq(reason, "Ownable: caller is not the owner", "Invalid revert reason");
+        }
+    }
+
+    function testFailCallExecutorDirectly() public {
+        address spell = address(new ChangeValueSpell(dripsContract));
+        Executor e = governance.executor();
+        e.exec(spell);
+    }
 }

--- a/src/governance/governance.t.sol
+++ b/src/governance/governance.t.sol
@@ -35,15 +35,17 @@ contract ChangeValueSpell is Spell {
 }
 
 contract GovernanceDelaySpellAction is Spell {
-    // storage of executor
-    // immutable variables like owner are not part of the storage
-    uint256 public minDelay; // first slot
+    Governance public immutable governance;
+
+    constructor(Governance governance_) {
+        governance = governance_;
+    }
 
     // constant and in spell action
     uint256 public constant MIN_DELAY = 1 days;
 
     function execute() public override {
-        minDelay = MIN_DELAY;
+        governance.setMinDelay(MIN_DELAY);
     }
 }
 
@@ -121,17 +123,16 @@ contract GovernanceTest is DSTest {
     }
 
     function testMinDelayChange() public {
-        Executor e = governance.executor();
         // pre condition
-        assertEq(e.minDelay(), 0, "delay-pre-condition");
+        assertEq(governance.minDelay(), 0, "delay-pre-condition");
 
-        address spell = address(new GovernanceDelaySpellAction());
+        address spell = address(new GovernanceDelaySpellAction(governance));
         governance.schedule(address(spell), block.timestamp);
         assertPreCondition();
         governance.execute(address(spell));
 
         // post condition
-        assertEq(e.minDelay(), 1 days, "delay-pre-condition");
+        assertEq(governance.minDelay(), 1 days, "delay-pre-condition");
     }
 
     function testScheduleNotOwner() public {


### PR DESCRIPTION
I added a simple governance inspired by MakerDAO Governance.

I tried to make a simplified version with only core features.
- schedule a spell action with timeDelay
- unSchedule a spell action 
- execute a spell action after time delay has passed

The PR is still in draft mode.  I still want to add investigate features and more tests etc. 

https://docs.makerdao.com/smart-contract-modules/governance-module

**DS Pause Integration tests**
The integration tests here, helps to understand how the fit together.
https://github.com/dapphub/ds-pause/blob/master/src/integration.t.sol

**Open Questions**
- Should we adopt the Spell or only the SpellAction pattern for Radicle?
- Should we add the extcodehash `tag` also for security reasons?
- https://eips.ethereum.org/EIPS/eip-1052