### PR TITLE
feat: change template in Radicle Registry

### DIFF
--- a/src/registry.sol
+++ b/src/registry.sol
@@ -35,7 +35,7 @@ contract RadicleRegistry is Ownable {
     address public dripsTokenTemplate;
     uint256 public nextId;
 
-    mapping(uint256 => address) public usedTemplate;
+    mapping(uint256 => address) public dripsToken;
 
     constructor(
         DaiDripsHub hub_,
@@ -59,8 +59,8 @@ contract RadicleRegistry is Ownable {
         string calldata contractURI,
         InputType[] calldata inputTypes,
         SplitsReceiver[] memory splits
-    ) public returns (address) {
-        address fundingToken = Clones.cloneDeterministic(dripsTokenTemplate, bytes32(nextId));
+    ) public returns (address fundingToken) {
+        fundingToken = Clones.cloneDeterministic(dripsTokenTemplate, bytes32(nextId));
         IDripsToken(fundingToken).init(
             name,
             symbol,
@@ -71,16 +71,8 @@ contract RadicleRegistry is Ownable {
             splits
         );
         emit NewProject(dripsTokenTemplate, fundingToken, projectOwner, name);
-        usedTemplate[nextId] = dripsTokenTemplate;
+        dripsToken[nextId] = fundingToken;
         nextId++;
-        return fundingToken;
-    }
-
-    function projectAddr(uint256 id) public view returns (address) {
-        if (id >= nextId) {
-            return address(0x0);
-        }
-        return Clones.predictDeterministicAddress((usedTemplate[id]), bytes32(id));
     }
 
     function changeBuilder(IBuilder newBuilder) public onlyOwner {

--- a/src/registry.sol
+++ b/src/registry.sol
@@ -1,26 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.7;
 
-import {DripsToken, InputType, SplitsReceiver} from "./token.sol";
+import {DripsToken, IDripsToken, InputType, SplitsReceiver} from "./token.sol";
 import {DaiDripsHub} from "drips-hub/DaiDripsHub.sol";
 import {Clones} from "openzeppelin-contracts/proxy/Clones.sol";
 import {IBuilder} from "./builder/interface.sol";
 import {Ownable} from "openzeppelin-contracts/access/Ownable.sol";
 
-interface IDripsToken {
-    function init(
-        string calldata name_,
-        string calldata symbol_,
-        address owner,
-        string calldata contractURI_,
-        InputType[] memory inputTypes,
-        IBuilder builder_,
-        SplitsReceiver[] memory splits
-    ) external;
-}
-
 contract RadicleRegistry is Ownable {
-    address public governance;
     IBuilder public builder;
 
     event NewProject(
@@ -44,7 +31,7 @@ contract RadicleRegistry is Ownable {
     ) {
         _transferOwnership(owner_);
         changeBuilder(builder_);
-        dripsTokenTemplate = address(new DripsToken(hub_));
+        changeTemplate(address(new DripsToken(hub_)));
     }
 
     function changeTemplate(address newTemplate) public onlyOwner {

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -48,13 +48,15 @@ contract RegistryTest is DSTest {
             streaming: true
         });
 
-        DripsToken nftRegistry = radicleRegistry.newProject(
-            name,
-            symbol,
-            address(this),
-            ipfsHash,
-            nftTypes,
-            new SplitsReceiver[](0)
+        DripsToken nftRegistry = DripsToken(
+            radicleRegistry.newProject(
+                name,
+                symbol,
+                address(this),
+                ipfsHash,
+                nftTypes,
+                new SplitsReceiver[](0)
+            )
         );
         assertEq(nftRegistry.owner(), address(this));
         assertEq(nftRegistry.name(), name);

--- a/src/test/registry.t.sol
+++ b/src/test/registry.t.sol
@@ -63,7 +63,7 @@ contract RegistryTest is DSTest {
         assertEq(nftRegistry.symbol(), symbol);
         assertEq(nftRegistry.contractURI(), ipfsHash);
         assertEq(address(nftRegistry.hub()), address(hub));
-        assertEq(address(radicleRegistry.projectAddr(0)), address(nftRegistry));
+        assertEq(address(radicleRegistry.dripsToken(0)), address(nftRegistry));
         (uint64 limit, uint64 minted, uint128 minAmtPerSec, , ) = nftRegistry.nftTypes(0);
         assertEq(limit, limitTypeZero);
         assertEq(minAmtPerSec, 10);
@@ -79,8 +79,8 @@ contract RegistryTest is DSTest {
 
     function testProjectAddr() public {
         address nftRegistry = newNewTokenRegistry();
-        assertEq(address(radicleRegistry.projectAddr(0)), nftRegistry);
-        assertEq(address(radicleRegistry.projectAddr(1)), address(0));
+        assertEq(address(radicleRegistry.dripsToken(0)), nftRegistry);
+        assertEq(address(radicleRegistry.dripsToken(1)), address(0));
     }
 
     function testChangeGovernance() public {

--- a/src/token.sol
+++ b/src/token.sol
@@ -16,7 +16,19 @@ struct InputType {
     string ipfsHash;
 }
 
-contract DripsToken is ERC721, Ownable {
+interface IDripsToken {
+    function init(
+        string calldata name_,
+        string calldata symbol_,
+        address owner,
+        string calldata contractURI_,
+        InputType[] memory inputTypes,
+        IBuilder builder_,
+        SplitsReceiver[] memory splits
+    ) external;
+}
+
+contract DripsToken is ERC721, Ownable, IDripsToken {
     address public immutable deployer;
     DaiDripsHub public immutable hub;
     IDai public immutable dai;
@@ -93,7 +105,7 @@ contract DripsToken is ERC721, Ownable {
         InputType[] memory inputTypes,
         IBuilder builder_,
         SplitsReceiver[] memory splits
-    ) public {
+    ) public override {
         require(!initialized, "already-initialized");
         initialized = true;
         require(msg.sender == deployer, "not-deployer");


### PR DESCRIPTION
- constructor creates first DripsToken template
- afterwards replaceable
- to calculate the address we need to keep track which template has been used
   - we could optimise this further with an array and store the counter and template address every-time it changes
   - than we only need to iterate this array to find your used template