### PR TITLE
feat: metadata ipfs publisher

### DIFF
--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -2,13 +2,12 @@
 pragma solidity ^0.8.7;
 
 contract MetaData {
-    event MultiHash(address indexed addr, uint8 hashFunction, uint8 size, bytes32 digest);
+    event MultiHash(address indexed addr, bytes multiHash);
 
-    function publish(
-        uint8 hashFunction,
-        uint8 size,
-        bytes32 digest
-    ) external {
-        emit MultiHash(msg.sender, hashFunction, size, digest);
+    /// @notice publish an IPFS hash as an event
+    /// @param multiHash as bytes array
+    /// more information: https://github.com/multiformats/multihash
+    function publish(bytes calldata multiHash) external {
+        emit MultiHash(msg.sender, multiHash);
     }
 }

--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -6,8 +6,11 @@ contract MetaData {
 
     /// @notice publish an IPFS hash as an event
     /// @param multiHash as bytes array
-    /// more information: https://github.com/multiformats/multihash
     function publish(bytes calldata multiHash) external {
+        // correct multiHash construction see https://github.com/multiformats/multihash
+        // 0-1  bytes:  hashFunction
+        // 1-2  bytes:  size
+        // 2-34 bytes:  hash (in most cases 32 bytes but not guranteed)
         emit MultiHash(msg.sender, multiHash);
     }
 }

--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+contract MetaData {
+    event MultiHash(address indexed addr, uint8 hashFunction, uint8 size, bytes32 digest);
+
+    function publish(
+        uint8 hashFunction,
+        uint8 size,
+        bytes32 digest
+    ) external {
+        emit MultiHash(msg.sender, hashFunction, size, digest);
+    }
+}

--- a/src/test/metadata.t.sol
+++ b/src/test/metadata.t.sol
@@ -20,6 +20,7 @@ contract MetaDataTest is DSTest {
         bytes32 digest = bytes32(
             0x9bc4d23950b5a91c9dc71883209424a145574a5e0f9aabd34a5f4ffc7f759409
         );
-        metadata.publish(hashFunction, size, digest);
+        bytes memory multiHash = abi.encode(hashFunction, size, digest);
+        metadata.publish(multiHash);
     }
 }

--- a/src/test/metadata.t.sol
+++ b/src/test/metadata.t.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.7;
+
+import "ds-test/test.sol";
+import {MetaData} from "../metadata.sol";
+
+// Libary for base58 encoding https://github.com/saurfang/ipfs-multihash-on-solidity
+contract MetaDataTest is DSTest {
+    MetaData public metadata;
+
+    function setUp() public {
+        metadata = new MetaData();
+    }
+
+    function testStoreMultiHash() public {
+        // multiHash base58 example "QmYphyME6tvpmLUaz2zG7zNGJNnDpPkecj5Egg3eERDafA";
+        // in hex 12209bc4d23950b5a91c9dc71883209424a145574a5e0f9aabd34a5f4ffc7f759409
+        uint8 hashFunction = uint8(0x12);
+        uint8 size = uint8(0x20);
+        bytes32 digest = bytes32(
+            0x9bc4d23950b5a91c9dc71883209424a145574a5e0f9aabd34a5f4ffc7f759409
+        );
+        metadata.publish(hashFunction, size, digest);
+    }
+}

--- a/src/test/metadata.t.sol
+++ b/src/test/metadata.t.sol
@@ -15,6 +15,9 @@ contract MetaDataTest is DSTest {
     function testStoreMultiHash() public {
         // multiHash base58 example "QmYphyME6tvpmLUaz2zG7zNGJNnDpPkecj5Egg3eERDafA";
         // in hex 12209bc4d23950b5a91c9dc71883209424a145574a5e0f9aabd34a5f4ffc7f759409
+        // 0-1:  hashFunction
+        // 1-2:  size
+        // 2-34: hash
         uint8 hashFunction = uint8(0x12);
         uint8 size = uint8(0x20);
         bytes32 digest = bytes32(


### PR DESCRIPTION
I added a simple contract to publish the ipfs hash (multihash) in form of events.

I think we only need it off-chain so only emitting an event should be enough.

This call costs `142 gas`.  We could potentially only pass a `calldata bytes` array and do a length 34 bytes check in assembly. Maybe even cheaper.