### PR TITLE
feat: added multihash event with id

### DIFF
--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -2,15 +2,24 @@
 pragma solidity ^0.8.7;
 
 contract MetaData {
-    event MultiHash(address indexed addr, bytes multiHash);
+    bytes32 public constant DEFAULT_ID = "identity";
+
+    // correct multiHash construction see https://github.com/multiformats/multihash
+    // 0-1  bytes:  hashFunction
+    // 1-2  bytes:  size
+    // 2-34 bytes:  hash (in most cases 32 bytes but not guranteed)
+    event MultiHash(bytes32 indexed id, address indexed addr, bytes multiHash);
 
     /// @notice publish an IPFS hash as an event
     /// @param multiHash as bytes array
     function publish(bytes calldata multiHash) external {
-        // correct multiHash construction see https://github.com/multiformats/multihash
-        // 0-1  bytes:  hashFunction
-        // 1-2  bytes:  size
-        // 2-34 bytes:  hash (in most cases 32 bytes but not guranteed)
-        emit MultiHash(msg.sender, multiHash);
+        emit MultiHash(DEFAULT_ID, msg.sender, multiHash);
+    }
+
+    /// @notice publish an IPFS hash as an event with an id
+    /// @param multiHash as bytes array
+    /// @param id identifier for the multiHash
+    function publish(bytes32 id, bytes calldata multiHash) external {
+        emit MultiHash(id, msg.sender, multiHash);
     }
 }

--- a/src/metadata.sol
+++ b/src/metadata.sol
@@ -2,24 +2,24 @@
 pragma solidity ^0.8.7;
 
 contract MetaData {
-    bytes32 public constant DEFAULT_ID = "identity";
+    bytes32 public constant DEFAULT_ID = "";
 
     // correct multiHash construction see https://github.com/multiformats/multihash
     // 0-1  bytes:  hashFunction
     // 1-2  bytes:  size
     // 2-34 bytes:  hash (in most cases 32 bytes but not guranteed)
-    event MultiHash(bytes32 indexed id, address indexed addr, bytes multiHash);
+    event MultiHash(address indexed addr, bytes32 indexed id, bytes multiHash);
 
     /// @notice publish an IPFS hash as an event
     /// @param multiHash as bytes array
     function publish(bytes calldata multiHash) external {
-        emit MultiHash(DEFAULT_ID, msg.sender, multiHash);
+        emit MultiHash(msg.sender, DEFAULT_ID, multiHash);
     }
 
     /// @notice publish an IPFS hash as an event with an id
     /// @param multiHash as bytes array
     /// @param id identifier for the multiHash
     function publish(bytes32 id, bytes calldata multiHash) external {
-        emit MultiHash(id, msg.sender, multiHash);
+        emit MultiHash(msg.sender, id, multiHash);
     }
 }

--- a/src/test/metadata.t.sol
+++ b/src/test/metadata.t.sol
@@ -26,4 +26,15 @@ contract MetaDataTest is DSTest {
         bytes memory multiHash = abi.encode(hashFunction, size, digest);
         metadata.publish(multiHash);
     }
+
+    function testStoreMultiHashWithId() public {
+        bytes32 id = "testId";
+        uint8 hashFunction = uint8(0x12);
+        uint8 size = uint8(0x20);
+        bytes32 digest = bytes32(
+            0x9bc4d23950b5a91c9dc71883209424a145574a5e0f9aabd34a5f4ffc7f759409
+        );
+        bytes memory multiHash = abi.encode(hashFunction, size, digest);
+        metadata.publish(id, multiHash);
+    }
 }


### PR DESCRIPTION
The main idea is to allow more flexibility with publishing metadata events by introducing an `id` 